### PR TITLE
Remove --no-color option

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -98,7 +98,7 @@ class Runner extends Component
      */
     protected function buildCommand($cmd)
     {
-        return $this->getPHPExecutable() . ' ' . Yii::getAlias($this->yiiscript) . ' ' . $cmd . ' --no-color 2>&1';
+        return $this->getPHPExecutable() . ' ' . Yii::getAlias($this->yiiscript) . ' ' . $cmd . ' 2>&1';
     }
 
     /**


### PR DESCRIPTION
The --no-color option is no longer supported by the Yii Console Runner. If the Terminal is able to support colors is determined automatically:

http://www.yiiframework.com/doc-2.0/guide-tutorial-console.html#formatting-and-colors

This option needs to be removed, the run command will fail otherwise.