### PR TITLE
change PHP_BINDIR by PHP_BINARY in method getPHPExecutable()

### DIFF
--- a/Runner.php
+++ b/Runner.php
@@ -112,6 +112,6 @@ class Runner extends Component
             return $this->phpexec;
         }
 
-        return PHP_BINDIR . '/php';
+        return PHP_BINARY;
     }
 }


### PR DESCRIPTION
This change is for solve a problem in windows systems where PHP_BINDIR returns something similar to "C:\php" while PHP_BINARY returns full path of php from its source